### PR TITLE
Revert "HaikuCompositor: use opaque region"

### DIFF
--- a/HaikuCompositor.cpp
+++ b/HaikuCompositor.cpp
@@ -220,14 +220,6 @@ void WaylandView::Draw(BRect dirty)
 				mode = B_OP_COPY;
 				break;
 		}
-		if (mode == B_OP_ALPHA && fSurface->fState.opaqueRgn.has_value()) {
-			viewLocked->ConstrainClippingRegion(&fSurface->fState.opaqueRgn.value());
-			viewLocked->SetDrawingMode(B_OP_COPY);
-			viewLocked->DrawBitmap(bmp);
-			BRegion remaining = viewLocked->Bounds();
-			remaining.Exclude(&fSurface->fState.opaqueRgn.value());
-			viewLocked->ConstrainClippingRegion(&remaining);
-		}
 		viewLocked->SetDrawingMode(mode);
 		viewLocked->DrawBitmap(bmp);
 	}


### PR DESCRIPTION
Reverting 3e61d9bab165bafaba8b9b51be08b28bd079f049 fixes #20

I wonder why that change affects redrawing only when CPU is busy.