### PR TITLE
HaikuOutput: Expose the correct make, model, and physical size

### DIFF
--- a/HaikuOutput.cpp
+++ b/HaikuOutput.cpp
@@ -38,7 +38,21 @@ void HaikuOutputGlobal::Bind(struct wl_client *wl_client, uint32_t version, uint
 	BScreen screen;
 	int32_t width = (int32_t)screen.Frame().Width() + 1;
 	int32_t height = (int32_t)screen.Frame().Height() + 1;
-	output->SendGeometry(0, 0, (float)width * 0.3528, (float)height * 0.3528, WlOutput::subpixelUnknown, "Unknown make", "Unknown model", WlOutput::transformNormal);
+
+	monitor_info info;
+	float width_mm = (float)width * 0.3528;
+	float height_mm = (float)height * 0.3528;
+	const char *make = "Unknown make";
+	const char *model = "Unknown model";
+	if (screen.GetMonitorInfo(&info) == B_OK) {
+		// From cm to mm.
+		width_mm = info.width * 10.0;
+		height_mm = info.height * 10.0;
+		make = info.vendor;
+		model = info.name;
+	}
+
+	output->SendGeometry(0, 0, width_mm, height_mm, WlOutput::subpixelUnknown, make, model, WlOutput::transformNormal);
 	output->SendMode(WlOutput::modeCurrent | WlOutput::modePreferred, width, height, 60000);
 	output->SendScale(1);
 	output->SendDone();


### PR DESCRIPTION
These all come from the BScreen class, so they are easy to expose.