### PR TITLE
Fix dead key handling in XKB map; filter unmapped non-modifier events

### DIFF
--- a/HaikuSeat.cpp
+++ b/HaikuSeat.cpp
@@ -171,6 +171,28 @@ static uint32_t FromHaikuModifiers(uint32 haikuModifiers)
 	return wlModifiers;
 }
 
+static bool IsModifierKey(uint32 haikuKey)
+{
+	switch (FromHaikuKeyCode(haikuKey)) {
+		case KEY_SCROLLLOCK:
+		case KEY_NUMLOCK:
+		case KEY_CAPSLOCK:
+		case KEY_LEFTSHIFT:
+		case KEY_RIGHTSHIFT:
+		case KEY_LEFTCTRL:
+		case KEY_RIGHTCTRL:
+		case KEY_LEFTALT:
+		case KEY_RIGHTALT:
+		case KEY_LEFTMETA:
+		case KEY_RIGHTMETA:
+		case KEY_COMPOSE:
+			return true;
+		default:
+			break;
+	}
+	return false;
+}
+
 class SurfaceCursorHook: public HaikuSurface::Hook {
 public:
 	BPoint fHotspot;
@@ -414,6 +436,7 @@ bool HaikuSeatGlobal::MessageReceived(HaikuSurface *surface, BMessage *msg)
 			if (fKeyboardFocus != surface) return false;
 			int32 key;
 			msg->FindInt32("key", &key);
+			if ((msg->what == B_UNMAPPED_KEY_UP || msg->what == B_UNMAPPED_KEY_DOWN) && !IsModifierKey(key)) return false;
 			uint32_t state = (msg->what == B_KEY_UP || msg->what == B_UNMAPPED_KEY_UP) ? WlKeyboard::keyStateReleased : WlKeyboard::keyStatePressed;
 
 			uint32_t wlKey = FromHaikuKeyCode(key);

--- a/XkbKeymap.cpp
+++ b/XkbKeymap.cpp
@@ -61,7 +61,7 @@ static uint32 GetOffsetForLevel(key_map *map, uint32 haikuKey, int level)
 	}
 }
 
-static void WriteSymbol(FILE *file, uint32 haikuKey, char *keyBuffer, uint32 offset)
+static void WriteSymbol(FILE *file, uint32 haikuKey, char *keyBuffer, uint32 offset, const key_map* map)
 {
 	switch (haikuKey) {
 		case 0x02: fprintf(file, "F1"); return;
@@ -77,6 +77,17 @@ static void WriteSymbol(FILE *file, uint32 haikuKey, char *keyBuffer, uint32 off
 		case 0x0c: fprintf(file, "F11"); return;
 		case 0x0d: fprintf(file, "F12"); return;
 		case 0x0e: fprintf(file, "Print"); return;
+
+		case 0x4b: fprintf(file, "Shift_L"); return;
+		case 0x56: fprintf(file, "Shift_R"); return;
+		case 0x5c: fprintf(file, "Control_L"); return;
+		case 0x60: fprintf(file, "Control_R"); return;
+		case 0x5d: fprintf(file, "Alt_L"); return;
+		case 0x5f: fprintf(file, "Alt_R"); return;
+		case 0x66: fprintf(file, "Super_L"); return;
+		case 0x67: fprintf(file, "Super_R"); return;
+		case 0x68: fprintf(file, "Menu"); return;
+
 		case 0x0f: fprintf(file, "Scroll_Lock"); return;
 		case 0x10: fprintf(file, "Pause"); return;
 		case 0x22: fprintf(file, "Num_Lock"); return;
@@ -129,6 +140,39 @@ static void WriteSymbol(FILE *file, uint32 haikuKey, char *keyBuffer, uint32 off
 	if (codepoint == 0) {
 		fprintf(file, "NoSymbol");
 		return;
+	}
+
+	if (map != NULL) {
+		const char* dead = NULL;
+		switch (codepoint) {
+			case 0x0027:
+				if (map->acute_tables) dead = "dead_acute";
+				break;
+			case 0x0022:
+				if (map->dieresis_tables) dead = "dead_diaeresis";
+				break;
+			case 0x0060:
+				if (map->grave_tables) dead = "dead_grave";
+				break;
+			case 0x007E:
+				if (map->tilde_tables) dead = "dead_tilde";
+				break;
+			case 0x005E:
+				if (map->circumflex_tables) dead = "dead_circumflex";
+				break;
+			case 0x00B4:
+				if (map->acute_tables) dead = "dead_acute";
+				break;
+			case 0x00A8:
+				if (map->dieresis_tables) dead = "dead_diaeresis";
+				break;
+			default:
+				break;
+		}
+		if (dead != NULL) {
+			fprintf(file, "%s", dead);
+			return;
+		}
 	}
 
 	switch (codepoint) {
@@ -393,7 +437,7 @@ static void GenerateSymbols(FILE *file, key_map *map, char *keyBuffer)
 			};
 
 			for (int level = 0; level < 4; level++) {
-				WriteSymbol(file, haikuKey, keyBuffer, offsets[level]);
+				WriteSymbol(file, haikuKey, keyBuffer, offsets[level], map);
 				if (level < 3) fprintf(file, ", ");
 			}
 
@@ -414,7 +458,7 @@ static void GenerateSymbols(FILE *file, key_map *map, char *keyBuffer)
 
 			if (!foundUS) {
 				for (int level = 0; level < 4; level++) {
-					WriteSymbol(file, haikuKey, keyBuffer, offsets[level]);
+					WriteSymbol(file, haikuKey, keyBuffer, offsets[level], map);
 					if (level < 3) fprintf(file, ", ");
 				}
 			}


### PR DESCRIPTION
* Add dead key support (acute, grave, diaeresis, etc.) using Haiku’s accent tables
* Map modifier keys properly in XKB (Shift_L, Alt_R, Super_L, etc.)
* Suppress unmapped key events for non-modifiers to avoid garbage input in Wayland clients