### PR TITLE
Add dynamic refresh rate

### DIFF
--- a/HaikuCompositor.cpp
+++ b/HaikuCompositor.cpp
@@ -118,6 +118,7 @@ private:
 
 	HaikuSurface *fSurface;
 	uint32 fOldMouseBtns = 0;
+	bool fFramerateLimitDisabled = false;
 	WaylandEnv *fActiveWlEnv {};
 
 public:
@@ -131,14 +132,24 @@ public:
 	void WindowActivated(bool active) final;
 	void MessageReceived(BMessage *msg) final;
 	void Draw(BRect dirty);
+	void Pulse(void);
 };
 
 
 WaylandView::WaylandView(HaikuSurface *surface):
-	BView(BRect(), "WaylandView", B_FOLLOW_NONE, B_WILL_DRAW | B_TRANSPARENT_BACKGROUND | B_INPUT_METHOD_AWARE),
+	BView(BRect(), "WaylandView", B_FOLLOW_NONE, B_WILL_DRAW | B_TRANSPARENT_BACKGROUND | B_INPUT_METHOD_AWARE | B_PULSE_NEEDED),
 	fSurface(surface)
 {
 	SetViewColor(B_TRANSPARENT_COLOR);
+
+	char *envValue = getenv("HAIWAY_FRAMERATE_LIMIT");
+	if (envValue != NULL) {
+		fFramerateLimitDisabled = (strcmp(envValue, "disabled") == 0);
+		if (fFramerateLimitDisabled) {
+			SetFlags(Flags() & ~B_PULSE_NEEDED);
+			fprintf(stderr, "Frame rate limiting disabled\n");
+		}
+	}
 }
 
 WaylandView::~WaylandView()
@@ -244,9 +255,15 @@ void WaylandView::Draw(BRect dirty)
 		}
 	}
 
-	fSurface->CallFrameCallbacks();
+	if (fSurface && fFramerateLimitDisabled)
+		fSurface->CallFrameCallbacks();
 }
 
+void WaylandView::Pulse(void)
+{
+	if (fSurface && !fFramerateLimitDisabled)
+		fSurface->CallFrameCallbacks();
+}
 
 //#pragma mark - HaikuSurface
 

--- a/HaikuXdgPopup.cpp
+++ b/HaikuXdgPopup.cpp
@@ -28,6 +28,7 @@ WaylandPopupWindow::WaylandPopupWindow(HaikuXdgPopup *popup, BRect frame, const 
 	BWindow(frame, title, look, feel, flags, workspace),
 	fPopup(popup)
 {
+	SetPulseRate(1000000 / 60); // 60 fps
 }
 
 bool WaylandPopupWindow::QuitRequested()


### PR DESCRIPTION
* Calculate screen refresh rate dynamically in WaylandWindow
* Implement Pulse() method in WaylandView for frame callbacks
* Set initial 60 FPS pulse rate for WaylandPopupWindow
* Update refresh rate on window activation and workspace changes
* Add HAIWAY_FRAMERATE_LIMIT environment variable for disabling dynamic refresh rate